### PR TITLE
api call complete

### DIFF
--- a/notebook/netflixandchill.ipynb
+++ b/notebook/netflixandchill.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "\n",
     "# Import the OMDB API key\n",
-    "from api_keys import omdb_api_key"
+    "from api_keys import omdb_api_key\n"
    ]
   },
   {
@@ -58,9 +58,9 @@
    "outputs": [],
    "source": [
     "# Netflix date_added is the key column for filtering to 2019 - 2021 to align with Disney+ dataset date_added dates\n",
-    "# The following steps trim the \"September 24, 2018\" dates to remove extra spaces, and converts date_added to date format for filtering\n",
+    "# The following steps trim the \"September 24, 2018\" dates to remove extra spaces\n",
     "netflix_df['date_added'] = netflix_df['date_added'].str.strip()\n",
-    "netflix_df['date_added'] = pd.to_datetime(netflix_df['date_added'], errors='coerce')\n",
+    "# netflix_df['date_added'] = pd.to_datetime(netflix_df['date_added'], errors='coerce')\n",
     "\n",
     "# There are a handful of blank date_added that will impact date filtering\n",
     "netflix_blank_dates = netflix_df[netflix_df['date_added'].isna()]\n",
@@ -84,6 +84,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "80e576bc-1857-4e9a-91c6-3134a474a993",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract only the date portion and convert it to string\n",
+    "netflix_df['date_added'] = pd.to_datetime(netflix_df['date_added'], errors='coerce')\n",
+    "netflix_df['date_added'] = netflix_df['date_added'].dt.date.astype(str)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5d51d48f-85ff-4b88-bc7b-4841bad0f1db",
    "metadata": {},
    "outputs": [],
@@ -102,7 +114,7 @@
    "source": [
     "# Create Disney+ dataframe and review length\n",
     "disney_df = pd.DataFrame(disney_data)\n",
-    "disney_df.head()"
+    "len(disney_df)"
    ]
   },
   {
@@ -134,6 +146,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "998924cd-c132-462c-8ffb-67c5f44c5067",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract only the date portion and convert it to string\n",
+    "disney_df['date_added'] = pd.to_datetime(disney_df['date_added'], errors='coerce')\n",
+    "disney_df['date_added'] = disney_df['date_added'].dt.date.astype(str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1bffdd1-fafa-4e52-a8c4-197538c760fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sorted data frames by date_added\n",
+    "sorted_netflix_df = netflix_df.sort_values(by = 'date_added', ascending=False)\n",
+    "sorted_disney_df = disney_df.sort_values(by = 'date_added', ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "211f2344-0350-4e4d-8806-325e44289063",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Most recent 500 titles per platform\n",
+    "recentadd_netflix_df = sorted_netflix_df.head(500)\n",
+    "recentadd_disney_df = sorted_disney_df.head(500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e60ee9cd-4fa7-41ed-9bfe-ee5eda915b81",
    "metadata": {},
    "outputs": [],
@@ -146,13 +194,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "11084ac8-17f2-4e6e-8b62-4a4a755937bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-establishing filtered DataFrame as primary DataFrame for analysis\n",
+    "netflix_df = recentadd_netflix_df\n",
+    "disney_df = recentadd_disney_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "7c319f08-e34d-4719-8408-c6ebb8f209f9",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Add platform column to each streaming service to maintain association\n",
-    "netflix_df[\"platform\"] = \"Netflix\"\n",
-    "disney_df[\"platform\"] = \"Disney+\""
+    "netflix_df.loc[:, \"platform\"] = \"Netflix\"\n",
+    "disney_df.loc[:, \"platform\"] = \"Disney+\"\n"
    ]
   },
   {
@@ -163,17 +223,20 @@
    "outputs": [],
    "source": [
     "# Concatenate Netflix and Disney+ dataframes\n",
-    "combined_df = pd.concat([netflix_df, disney_df], ignore_index=True)"
+    "combined_df = pd.concat([netflix_df, disney_df], ignore_index=True)\n",
+    "len(combined_df)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba97b5e0-f51a-40ad-a1fd-42459a9596f8",
+   "id": "dbe6b15e-2ca0-4b3e-94b2-6f6d7dba735e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "combined_df.dtypes"
+    "# Find duplicate titles to remove from analysis\n",
+    "duplicate_titles = combined_df[combined_df.duplicated(subset=['title'])]\n",
+    "len(duplicate_titles)"
    ]
   },
   {
@@ -186,7 +249,6 @@
     "# Extract the primary genre from listed_in by pulling the first values within the list\n",
     "combined_df['listed_in'] = combined_df['listed_in'].str.split(',')\n",
     "combined_df['primary_genre'] = combined_df['listed_in'].str.get(0)\n",
-    "combined_df.head()\n",
     "\n",
     "# blank_genre = combined_df[combined_df['primary_genre'].isna()]\n",
     "# len(blank_genre)"
@@ -200,7 +262,21 @@
    "outputs": [],
    "source": [
     "# Clean dataframe with columns of importance for data analysis\n",
-    "combined_df = combined_df.loc[:, ['platform', 'show_id', 'type', 'title', 'date_added', 'release_year', 'primary_genre']]\n",
+    "combined_df = combined_df.loc[:, ['title', 'type','release_year', 'primary_genre', 'platform', 'date_added']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "420bcb13-d684-4464-93c8-df985b91f55d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert 'date_added' column to datetime\n",
+    "combined_df['date_added'] = pd.to_datetime(combined_df['date_added'])\n",
+    "# Extract year from 'date_added' and store it in a new column 'year_added'\n",
+    "combined_df['year_added'] = combined_df['date_added'].dt.year\n",
+    "\n",
     "combined_df.head()"
    ]
   },
@@ -212,8 +288,11 @@
    "outputs": [],
    "source": [
     "# Add empty columns for IMDb metadata to be pulled from API\n",
-    "combined_df['OMDb Rating'] = ''\n",
-    "combined_df['OMDb Votes'] = ''"
+    "combined_df['imdb_id'] = ''\n",
+    "combined_df['imdb_rating'] = ''\n",
+    "combined_df['imdb_votes'] = ''\n",
+    "combined_df['box_office_sales'] = ''\n",
+    "combined_df['production_cost'] = ''"
    ]
   },
   {
@@ -230,14 +309,61 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "efb314de-dc68-475e-bfa0-833759e26032",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TEST\n",
+    "# Response 200 testing\n",
+    "# url = \"http://www.omdbapi.com/?t=\"\n",
+    "# api_key = \"&apikey=\" + omdb_api_key\n",
+    "# response = requests.get(url + \"Aliens\" + api_key, verify=False)\n",
+    "# print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "52a294b7-8a90-4307-9067-7bed60a8df80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TEST\n",
+    "# Printing API URLs out\n",
+    "\n",
+    "# Establishing base URL for OMDB API\n",
+    "# url = \"http://www.omdbapi.com/\"\n",
+    "\n",
+    "# Construct the API request URL with the title and API key\n",
+    "# params = {\n",
+    "#        'apikey': omdb_api_key,\n",
+    "#    }\n",
+    "\n",
+    "# Loop through each title in the 'title' column of combined_df\n",
+    "# for index, row in combined_df.iterrows():\n",
+    "#    time.sleep(2) # Add a delay to avoid hitting the API too quickly\n",
+    "    \n",
+    "#    title = row['title']\n",
+    "#    params['t'] = title # get title from combined_df\n",
+    "    \n",
+    "# Construct the API URL\n",
+    "#    api_url = url + \"?\" + \"&\".join([f\"{key}={value}\" for key, value in params.items()])\n",
+    "\n",
+    "# Print the API URL for the current title\n",
+    "#    print(\"API URL for\", title, \":\", api_url)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b6a0c9b-0cda-4a1d-a2a6-ad65af5d1611",
    "metadata": {},
    "outputs": [],
    "source": [
     "# this is being worked on - could not get api response to work (garrett) \n",
     "\n",
     "# Establishing base URL for OMDB API\n",
-    "url = \"http://www.omdbapi.com/?\"\n",
+    "url = \"http://www.omdbapi.com/\"\n",
     "\n",
     "# Construct the API request URL with the title and API key\n",
     "params = {\n",
@@ -247,59 +373,43 @@
     "# Loop through each title in the 'title' column of combined_df\n",
     "for index, row in combined_df.iterrows():\n",
     "    time.sleep(2) # Add a delay to avoid hitting the API too quickly\n",
-    "\n",
-    "    params['t'] = combined_df['title'] # get title from combined_df\n",
-    "\n",
-    "    # Establishing base URL for OMDB API\n",
-    "    url = \"http://www.omdbapi.com/?\"\n",
     "    \n",
+    "    title = row['title'] # get title from current row\n",
+    "    params['t'] = title # establish \"t\" parameter for current title\n",
+    " \n",
     "   # Run an API request for each of the titles\n",
-    "    omdb_response = requests.get(url, params=params, verify=False)\n",
-    "    print(omdb_response)"
+    "    try:\n",
+    "        # Parse the JSON and retrieve data\n",
+    "        omdb_response = requests.get(url, params=params, verify=False)\n",
+    "        omdb_data = omdb_response.json()\n",
+    "    \n",
+    "    # Parse out OMDB ratings, votes, etc.\n",
+    "        id = omdb_data.get('imdbID')\n",
+    "        rating = omdb_data.get('imdbRating')\n",
+    "        votes = omdb_data.get('imdbVotes')\n",
+    "        box_office_sales = omdb_data.get('BoxOffice')\n",
+    "        prod_cost = omdb_data.get('Production')\n",
+    "        \n",
+    "    # Assign OMDB information into combined_df\n",
+    "        combined_df.at[index, \"imdb_id\"] = id\n",
+    "        combined_df.at[index, \"imdb_rating\"] = rating\n",
+    "        combined_df.at[index, \"imdb_votes\"] = votes \n",
+    "        combined_df.at[index, \"box_office_sales\"] = box_office_sales \n",
+    "        combined_df.at[index, \"production_cost\"] = prod_cost\n",
+    "\n",
+    "                             \n",
+    "        print(f\"Data retrieved for '{title}': imdbRating = {rating}, imdbVotes = {votes}\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"Failed to fetch data for '{title}': {e}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cae895a0-2cbd-40df-a0ad-db2164e801c7",
+   "id": "b47a8d82-6b8a-4230-9019-18e38dc466c6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# another try for api call structure\n",
-    "# Establishing base URL for OMDB API\n",
-    "url = \"http://www.omdbapi.com/?\"\n",
-    "\n",
-    "# Loop through each title in the 'title' column of combined_df\n",
-    "for index, title in enumerate(combined_df['title']):\n",
-    "    time.sleep(2) # Add a delay to avoid hitting the API too quickly\n",
-    "    \n",
-    "    # Construct the API request URL with the title and API key\n",
-    "    params = {\n",
-    "        'apikey': omdb_api_key,\n",
-    "        't': title\n",
-    "    }\n",
-    "\n",
-    "    # Run an API request for each of the titles\n",
-    "    try:\n",
-    "        # Parse the JSON and retrieve data\n",
-    "        omdb_response = requests.get(url, params=params, verify=False)\n",
-    "        omdb_data = response.json()\n",
-    "    \n",
-    "    # Parse out OMDB ratings, votes, etc.\n",
-    "        rating = omdb_data[] # review and find correct column\n",
-    "        votes = omdb_data[] # review and find correct column\n",
-    "        \n",
-    "    # Assign OMDB information into combined_df\n",
-    "        combined_df.at[index, \"OMDb Rating\"] = rating, \n",
-    "        combined_df.at[index, \"OMDb Votes\"] = rating \n",
-    "                             # add in other co\n",
-    "                            })\n",
-    "    \n",
-    " # If an error is experienced, skip the title\n",
-    "    except:\n",
-    "        print(\"Title not found. Skipping...\")\n",
-    "    pass"
-   ]
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- tested response, 200 received, needed to create new API key and activate
- tested API call URLs to confirm for loop over combined_df
- formatted datetime as just date
- extracted date_added year into new column
- created API metadata columns of interest, more can be added as needed
- prepared additional filtered dataframes, sorted by date_added, most recently added 500 as API limit is 1,000 daily...so may cause our dataset to be limited or solution how to figure out how to use different api keys to combat running against the limit for over 6,000 titles (if we review all titles within 2019-2021 span)
- do we filter out low genre numbers ahead of combining to get the "best" data that is the most "full" picture with a filtered to 500 per platform dataframe?